### PR TITLE
feat(bootstrap) Add bootstrap script

### DIFF
--- a/scripts/bootstrap/README.md
+++ b/scripts/bootstrap/README.md
@@ -1,0 +1,32 @@
+# Bootstrap
+The script provides the initial setup for the localhost on which it runs.
+
+What's installed:
+1. apt-transport-https  
+2. ca-certificates 
+3. curl 
+4. software-properties-common 
+5. jq
+6. docker
+
+## Ansible runner
+The final step of the initialization is building the Ansible runner image. It contains the Python `docker` module, so it can orchestrate containers.
+
+Main purpose: To simplify the further deployment of infrastructure.
+
+## How to use:
+
+```bash
+docker run --rm -it -v $(pwd)/src:/ansible/src ansible-runner:v*.*. ansible-playbook -i /ansible/src/inventory.ini /ansible/src/playbook.yml
+```
+
+* `--rm` - Deletes container after run.
+* `--it` - Runs interactively, displaying execution logs.
+*   `-v` - Attaches a volume with the playbook and inventory file.
+* `ansible-runner:v*.*.*` - The image name. Replace `*.*.*` with the speific version you are using.
+* `ansible-playbook` - Command to run Ansible playbook.
+* `-i` - Flag that specifies the path in the inventory file.
+* `/ansible/src/playbook.yml` - Path to the playbook file.
+
+
+

--- a/scripts/bootstrap/init.sh
+++ b/scripts/bootstrap/init.sh
@@ -1,0 +1,116 @@
+#!/bin/env bash
+
+# Ensure the script is run as root
+if [ "$(id -u)" != "0" ]; then
+   echo "This script must be run as root or by sudo user" 1>&2
+   exit 1
+fi
+
+# Define versions and package names as variables
+BASE_IMAGE="python:3.12.2-slim"
+DOCKER_VER="7.0.0"
+ANSIBLE_VER="9.2.0"
+ANSIBLE_TAG="ansible-runner"
+ANSIBLE_DIR="/root/ansible-runner"
+ANSIBLE_DOCKERFILE="$ANSIBLE_DIR/Dockerfile"
+ANSIBLE_ENTRYPOINT="$ANSIBLE_DIR/entrypoint.sh"
+
+# Function to update system
+update_system() {
+    echo "Updating system..."
+    apt-get update || { echo "Failed to update system. Exiting..."; exit 1; }
+}
+
+# Function to install prerequisites
+install_prerequisites() {
+    echo "Installing prerequisites..."
+    apt-get install -y apt-transport-https ca-certificates curl software-properties-common jq || { echo "Failed to install prerequisites. Exiting..."; exit 1; }
+}
+
+# Function to install Docker
+install_docker() {
+    echo "Installing Docker..."	
+    install -m 0755 -d /etc/apt/keyrings
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+    chmod a+r /etc/apt/keyrings/docker.asc
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null || { echo "Failed to add Docker repository to apt sources."; exit 1; }
+    apt-get update
+    apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin || { echo "Failed to install Docker."; exit 1; }
+}
+
+create_dockerfile_ansible_runner() {
+    cat > "$ANSIBLE_DOCKERFILE" <<EOF
+# Use build argument for the base image
+ARG BASE_IMAGE=$BASE_IMAGE
+
+# Use an official Python runtime as a parent image
+FROM \$BASE_IMAGE
+
+# Environment variables to be added when building
+ENV DOCKER_VER=$DOCKER_VER
+ENV ANSIBLE_VER=$ANSIBLE_VER
+
+# Install dependencies required for ansible and ssh connections
+RUN apt-get update && \\
+    apt-get install -y --no-install-recommends \\
+    ssh \\
+    openssh-client \\
+    rsyslog \\
+    systemd \\
+    && apt-get clean \\
+    && rm -rf /var/lib/apt/lists/* \\
+    && python -m pip install --upgrade pip cffi \\
+    && pip install ansible==\${ANSIBLE_VER} \\
+    && pip install docker==\${DOCKER_VER}
+
+# Set the working directory in the container to /src
+WORKDIR /src
+
+# Copy the entrypoint script and src directory into the container
+COPY entrypoint.sh /entrypoint.sh
+
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["ansible-playbook", "--version"]
+EOF
+
+    echo "Dockerfile created."
+}
+
+create_entrypoint_ansible_runner() {
+    cat > "$ANSIBLE_ENTRYPOINT" <<EOF
+#!/bin/bash
+
+# Default to showing the Ansible version if no command is specified
+if [ \$# -eq 0 ]; then
+    exec ansible-playbook --version
+else
+    exec "\$@"
+fi
+EOF
+
+    chmod +x "$ANSIBLE_ENTRYPOINT"
+    echo "Entrypoint script created."
+}
+
+create_ansible_runner() {
+    echo "Creating ansible-runner container..."
+    mkdir -p "$ANSIBLE_DIR"
+    create_dockerfile_ansible_runner || { echo "Failed to create Dockerfile."; exit 1; }
+    create_entrypoint_ansible_runner || { echo "Failed to create entrypoint script."; exit 1; }
+    cd "$ANSIBLE_DIR" || exit
+    docker build -t "$ANSIBLE_TAG:$ANSIBLE_VER" . || { echo "Failed to build ansible-runner container."; exit 1; }
+    echo "Ansible runner container created."
+}
+
+main() {
+    update_system
+    install_prerequisites
+    install_docker
+    create_ansible_runner
+}
+
+# Call the main function
+main
+


### PR DESCRIPTION
Bootstrap script should be launced on fresh instance as root or sudo. It will install dependencies, docker and ansible-runner. Ansible-runner can be used for further infrastructure deployment by adding volume with playbook.yml and inventory.ini to /ansible/src